### PR TITLE
`cycle-profile` rewrite

### DIFF
--- a/cycle-profile.lua
+++ b/cycle-profile.lua
@@ -9,24 +9,8 @@
     The script will print the profile description to the screen when switching, if there is no profile description, then it just prints the name
 ]]--
 
---change this to change what character separates the profile names
-local seperator = ";"
-
 local mp = require 'mp'
 local msg = require 'mp.msg'
-
---splits the profiles string into an array of profile names
---function taken from: https://stackoverflow.com/questions/1426954/split-string-in-lua/7615129#7615129
-local function mysplit (inputstr, sep)
-    if sep == nil then
-            sep = "%s"
-    end
-    local t={}
-    for str in string.gmatch(inputstr, "([^"..sep.."]+)") do
-            table.insert(t, str)
-    end
-    return t
-end
 
 --table of all available profiles and options
 local profileList = mp.get_property_native('profile-list')
@@ -75,7 +59,10 @@ local function printProfileDesc(profile)
     mp.osd_message(desc)
 end
 
-local function main(profileStr)
+local function main(...)
+    local profiles = {...}
+    local profileStr = table.concat(profiles, ';')
+
     --if there is not already an iterator for this cycle then it creates one
     if iterator[profileStr] == nil then
         msg.verbose('unknown cycle, creating new iterator')
@@ -84,7 +71,6 @@ local function main(profileStr)
     local i = iterator[profileStr]
 
     --converts the string into an array of profile names
-    local profiles = mysplit(profileStr, seperator)
     msg.verbose('cycling ' .. tostring(profiles))
     msg.verbose("number of profiles: " .. tostring(#profiles))
 

--- a/cycle-profile.lua
+++ b/cycle-profile.lua
@@ -3,10 +3,21 @@
     available at: https://github.com/CogentRedTester/mpv-scripts
 
     syntax:
-        script-message cycle-profiles "profile1;profile2;profile3"
+        script-message cycle-profiles profile1 profile2 "profile 3"
 
-    You must use semicolons to separate the profiles, do not include any spaces that are not part of the profile name.
-    The script will print the profile description to the screen when switching, if there is no profile description, then it just prints the name
+    You must put the name of the profile in quotes if it contains special characters like spaces.
+    The script will print the profile description to the screen when switching,
+    if there is no profile description, then it just prints the name.
+
+    If the `profile-restore` option is set on a profile, then cycling
+    off that profile will run the restore operation.
+    Cycling to an empty profile ("") will restore the previous profile
+    without enabling a new one, so to toggle a profile you can do:
+
+        script-message cycle-profiles profile1 ""
+    
+    Note that the script will not detect if a profile has already
+    been applied in any other manner.
 ]]--
 
 local mp = require 'mp'

--- a/cycle-profile.lua
+++ b/cycle-profile.lua
@@ -57,11 +57,13 @@ local function main(...)
     local prevProfile = profiles[prev_iterator]
     local newProfile = profiles[iterators[key]]
 
+    -- restore the previous profile
     if prev_iterator and profile_map[prevProfile] and profile_map[prevProfile]['profile-restore'] then
         msg.info('restoring profile', prevProfile)
         mp.commandv('apply-profile', prevProfile, 'restore')
     end
 
+    -- abort if the new profile is an empty string
     if newProfile == '' then
         mp.osd_message('restoring profiles')
         return

--- a/cycle-profile.lua
+++ b/cycle-profile.lua
@@ -35,10 +35,10 @@ local o = {
 
     -- the format string to use for the osd message
     -- see: https://www.lua.org/manual/5.1/manual.html#pdf-string.format
-    osd_format_string = "%s",
+    osd_format_string = '%s',
 
     -- the string to show when applying an empty profile ("")
-    osd_empty_string = "restoring profiles"
+    osd_empty_string = 'restoring profiles'
 }
 
 local mp = require 'mp'
@@ -75,30 +75,30 @@ local function main(osd, ...)
     end
 
     --converts the string into an array of profile names
-    msg.verbose('cycling ' .. tostring(profiles))
-    msg.verbose("number of profiles: " .. tostring(#profiles))
+    msg.verbose('cycling', key)
+    msg.verbose('number of profiles:', #profiles)
 
-    local prevProfile = profiles[prev_iterator]
-    local newProfile = profiles[iterators[key]]
+    local prev_profile = profiles[prev_iterator]
+    local new_profile = profiles[iterators[key]]
 
     -- restore the previous profile
-    if prev_iterator and profile_map[prevProfile] and profile_map[prevProfile]['profile-restore'] then
-        msg.info('restoring profile', prevProfile)
-        mp.commandv('apply-profile', prevProfile, 'restore')
+    if prev_iterator and profile_map[prev_profile] and profile_map[prev_profile]['profile-restore'] then
+        msg.info('restoring profile', prev_profile)
+        mp.commandv('apply-profile', prev_profile, 'restore')
     end
 
     -- abort if the new profile is an empty string
-    if newProfile == '' then
+    if new_profile == '' then
         if osd then mp.osd_message(o.osd_empty_string) end
         return
     end
 
     --sends the command to apply the profile
-    msg.info("applying profile", newProfile)
-    mp.commandv('apply-profile', newProfile)
+    msg.info('applying profile', new_profile)
+    mp.commandv('apply-profile', new_profile)
 
     --prints the profile description to the OSD
-    local desc = o.prefer_description and profile_map[newProfile]['profile-desc'] or newProfile
+    local desc = o.prefer_description and profile_map[new_profile]['profile-desc'] or new_profile
     if osd then mp.osd_message(o.osd_format_string:format(desc)) end
 end
 

--- a/cycle-profile.lua
+++ b/cycle-profile.lua
@@ -10,13 +10,14 @@
 ]]--
 
 --change this to change what character separates the profile names
-seperator = ";"
+local seperator = ";"
 
-msg = require 'mp.msg'
+local mp = require 'mp'
+local msg = require 'mp.msg'
 
 --splits the profiles string into an array of profile names
 --function taken from: https://stackoverflow.com/questions/1426954/split-string-in-lua/7615129#7615129
-function mysplit (inputstr, sep)
+local function mysplit (inputstr, sep)
     if sep == nil then
             sep = "%s"
     end
@@ -28,24 +29,24 @@ function mysplit (inputstr, sep)
 end
 
 --table of all available profiles and options
-profileList = mp.get_property_native('profile-list')
+local profileList = mp.get_property_native('profile-list')
 
 --keeps track of current profile for every unique cycle
-iterator = {}
+local iterator = {}
 
 --stores descriptions for profiles
 --once requested a description is stored here so it does not need to be found again
-profilesDescs = {}
+local profilesDescs = {}
 
 --if trying to cycle to an unknown profile this function is run to find a description to print
-function findDesc(profile)
+local function findDesc(profile)
     msg.verbose('unknown profile ' .. profile .. ', searching for description')
 
     for i = 1, #profileList, 1 do
         if profileList[i]['name'] == profile then
             msg.verbose('profile found')
             local desc = profileList[i]['profile-desc']
-            
+
             if desc ~= nil then
                 msg.verbose('description found')
                 profilesDescs[profile] = desc
@@ -63,7 +64,7 @@ end
 
 --prints the profile description to the OSD
 --if the profile has not been requested before during the session then it runs findDesc()
-function printProfileDesc(profile)
+local function printProfileDesc(profile)
     local desc = profilesDescs[profile]
     if desc == nil then
         findDesc(profile)
@@ -74,7 +75,7 @@ function printProfileDesc(profile)
     mp.osd_message(desc)
 end
 
-function main(profileStr)
+local function main(profileStr)
     --if there is not already an iterator for this cycle then it creates one
     if iterator[profileStr] == nil then
         msg.verbose('unknown cycle, creating new iterator')

--- a/script-opts/cycle_profiles.conf
+++ b/script-opts/cycle_profiles.conf
@@ -1,0 +1,16 @@
+# The default config file for cycle-profile
+# Available at: https://github.com/CogentRedTester/mpv-scripts
+
+# print messages to the osd when cycling profiles
+osd=yes
+
+# prefer the profile-desc string over the profile name
+# when printing osd messages
+prefer_description=yes
+
+# the format string to use for the osd message
+# see: https://www.lua.org/manual/5.1/manual.html#pdf-string.format
+osd_format_string=%s
+
+# the string to show when applying an empty profile ("")
+osd_empty_string=restoring profiles


### PR DESCRIPTION
Rewrites cycle-profile to use cleaner syntax and
support the profile-restore option.

Resolves #26