### PR TITLE
save-playlist: Handle empty strings

### DIFF
--- a/save-playlist.lua
+++ b/save-playlist.lua
@@ -31,6 +31,14 @@ local working = mp.get_property("working-directory", "")
 local function save_playlist(directory, name, relative)
     if not directory or not name then return end
     directory = mp.command_native({"expand-path", directory})
+
+    if string.len(directory) == 0 then
+        directory = utils.getcwd()
+    end
+    if string.len(name) == 0 then
+        name = os.time(os.date("!*t"))
+    end
+
     local path = directory.."/"..name..".m3u"
     local file = io.open(path, "w")
     if not file then msg.error("could not open file '"..path.."' for writing") ; return end

--- a/save-playlist.lua
+++ b/save-playlist.lua
@@ -36,7 +36,7 @@ local function save_playlist(directory, name, relative)
         directory = working
     end
     if string.len(name) == 0 then
-        name = os.time(os.date("!*t"))
+        name = 'untitled-playlist-'..os.time(os.date("!*t"))
     end
 
     local path = directory.."/"..name..".m3u"

--- a/save-playlist.lua
+++ b/save-playlist.lua
@@ -33,7 +33,7 @@ local function save_playlist(directory, name, relative)
     directory = mp.command_native({"expand-path", directory})
 
     if string.len(directory) == 0 then
-        directory = utils.getcwd()
+        directory = working
     end
     if string.len(name) == 0 then
         name = os.time(os.date("!*t"))


### PR DESCRIPTION
Currently, when you just press enter, and don't fill out the prompt, playlists get written to the root of your drive, as `/.m3u`. This doesn't make sense as a default behavior, so I made it use the current directory, and fallback to a unix timestamp for the playlist name to avoid duplicates in the path.